### PR TITLE
update gh action checkout vrs

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup bun
         uses: oven-sh/setup-bun@v1
         with:
@@ -25,7 +25,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup bun
         uses: oven-sh/setup-bun@v1
         with:
@@ -39,7 +39,7 @@ jobs:
     needs: [build, lint]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Download Artifact
         uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -4,7 +4,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup bun
         uses: oven-sh/setup-bun@v1
         with:
@@ -22,7 +22,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup bun
         uses: oven-sh/setup-bun@v1
         with:
@@ -37,7 +37,7 @@ jobs:
     needs: [build, lint]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Download Artifact
         uses: actions/download-artifact@v2
         with:


### PR DESCRIPTION
# Scope

Github Checkout action using deprecated Node version.

# Implementation

Updated Checkout version v2 -> v3
