### PR TITLE
shrink footer icons

### DIFF
--- a/src/components/Footer/index.scss
+++ b/src/components/Footer/index.scss
@@ -94,7 +94,7 @@
     align-items: center;
 
     svg {
-      height: 2.5em;
+      height: 2.3em;
     }
   }
 }


### PR DESCRIPTION
# Scope

Footer Icons too big.

# Implementation

Shrink footer icons 2.5em -> 2.3em.

# How to Test

- Scroll down to Footer
